### PR TITLE
possible fix

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,19 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta name="theme-color" content="#000000" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <meta name="theme-color" content="#000000" />
+  <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -22,12 +20,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>Fuze Callboard</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -37,5 +36,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/client/src/components/AdminPhones/AdminAgents/AdminAgents.js
+++ b/client/src/components/AdminPhones/AdminAgents/AdminAgents.js
@@ -32,7 +32,7 @@ export default class AdminAgents extends React.Component {
                 <AgentDisplay
                   key={agent.name}
                   userId={agent.userId}
-                  statusTimer={agent.statusTimer}
+                  statusTimer={agent.statusChangeTime}
                   callsTaken={agent.callsTaken}
                 />
               ];
@@ -46,7 +46,7 @@ export default class AdminAgents extends React.Component {
                 <AgentDisplay
                   key={agent.name}
                   userId={agent.userId}
-                  statusTimer={agent.statusTimer}
+                  statusTimer={agent.statusChangeTime}
                   callsTaken={agent.callsTaken}
                 />
               ];

--- a/client/src/components/AdminPhones/AdminAgents/AdminAgents.js
+++ b/client/src/components/AdminPhones/AdminAgents/AdminAgents.js
@@ -7,10 +7,10 @@ export default class AdminAgents extends React.Component {
     let adminOnCall = [];
 
     this.props.adminQueue.forEach(agent => {
-      if (agent.status === "Available") {
+      if (agent.agentStatus === "Available") {
         adminAvailable.push(agent);
       }
-      if (agent.status === "On a Call") {
+      if (agent.agentStatus === "On a Call") {
         adminOnCall.push(agent);
       }
     });

--- a/client/src/components/AdminPhones/AdminPaused/AdminPaused.js
+++ b/client/src/components/AdminPhones/AdminPaused/AdminPaused.js
@@ -7,10 +7,10 @@ export default class AdminPaused extends React.Component {
     let adminUnavailable = [];
 
     this.props.adminQueue.forEach(agent => {
-      if (agent.status === "Paused") {
+      if (agent.agentStatus === "Paused") {
         adminPaused.push(agent);
       }
-      if (agent.status === "Unavailable") {
+      if (agent.agentStatus === "Unavailable") {
         adminUnavailable.push(agent);
       }
     });

--- a/client/src/components/AdminPhones/AdminPaused/AdminPaused.js
+++ b/client/src/components/AdminPhones/AdminPaused/AdminPaused.js
@@ -32,7 +32,7 @@ export default class AdminPaused extends React.Component {
                 <AgentDisplay
                   key={agent.name}
                   userId={agent.userId}
-                  statusTimer={agent.statusTimer}
+                  statusTimer={agent.statusChangeTime}
                   callsTaken={agent.callsTaken}
                 />
               ];
@@ -46,7 +46,7 @@ export default class AdminPaused extends React.Component {
                 <AgentDisplay
                   key={agent.name}
                   userId={agent.userId}
-                  statusTimer={agent.statusTimer}
+                  statusTimer={agent.statusChangeTime}
                   callsTaken={agent.callsTaken}
                 />
               ];

--- a/client/src/components/AgentDisplay/AgentDisplay.js
+++ b/client/src/components/AgentDisplay/AgentDisplay.js
@@ -1,13 +1,50 @@
 import React from "react";
 
 export default class AgentDisplay extends React.Component {
+  ppSeconds(time) {
+    let hours = Math.floor(time / 3600);
+    time %= 3600;
+    let minutes = Math.floor(time / 60);
+    let seconds = time % 60;
+    if (hours === 0 && minutes === 0 && seconds < 10) {
+      return "0:0" + seconds;
+    } else if (hours === 0 && minutes === 0) {
+      return "00:" + seconds;
+    } else if (hours === 0 && minutes < 10 && seconds < 10) {
+      return "0" + minutes + ":0" + seconds;
+    } else if (hours === 0 && minutes < 10) {
+      return "0" + minutes + ":" + seconds;
+    } else if (hours === 0 && seconds < 10) {
+      return minutes + ":0" + seconds;
+    } else if (hours === 0) {
+      return minutes + ":" + seconds;
+    } else if (hours > 1 && minutes === 0 && seconds < 10) {
+      return hours + ":00:0" + seconds;
+    } else if (hours > 1 && minutes === 0) {
+      return hours + ":00:" + seconds;
+    } else if (hours > 1 && minutes < 10 && seconds < 10) {
+      return hours + ":0" + minutes + ":0" + seconds;
+    } else if (hours > 1 && minutes < 10) {
+      return hours + ":0" + minutes + seconds;
+    } else if (hours > 1 && seconds < 10) {
+      return hours + ":" + minutes + ":0" + seconds;
+    } else if (hours > 1) {
+      return hours + ":" + minutes + ":" + seconds;
+    } else {
+      return "—   ";
+    }
+  }
   render() {
+    let time = this.props.statusTimer;
+    let currentTime = Math.round(new Date().getTime() / 1000);
+    let difference = currentTime - time;
+    let userId = this.props.userId;
     return (
       <tbody>
         <tr>
-          <td>{this.props.userId}</td>
+          <td>{this.props.userId ? this.props.userId.substring(0, 10) : ""}</td>
           <td>{this.props.counter}</td>
-          <td align="right">{this.props.statusTimer}</td>
+          <td align="right">{this.ppSeconds(difference)}</td>
           <td align="right">{this.props.callsTaken}</td>
         </tr>
       </tbody>

--- a/client/src/components/AgentDisplay/AgentDisplay.js
+++ b/client/src/components/AgentDisplay/AgentDisplay.js
@@ -38,6 +38,7 @@ export default class AgentDisplay extends React.Component {
     let time = this.props.statusTimer;
     let currentTime = Math.round(new Date().getTime() / 1000);
     let difference = currentTime - time;
+
     return (
       <tbody>
         <tr>

--- a/client/src/components/AgentDisplay/AgentDisplay.js
+++ b/client/src/components/AgentDisplay/AgentDisplay.js
@@ -38,7 +38,6 @@ export default class AgentDisplay extends React.Component {
     let time = this.props.statusTimer;
     let currentTime = Math.round(new Date().getTime() / 1000);
     let difference = currentTime - time;
-    let userId = this.props.userId;
     return (
       <tbody>
         <tr>

--- a/client/src/components/StudentPhones/StudentAgents/StudentAgents.js
+++ b/client/src/components/StudentPhones/StudentAgents/StudentAgents.js
@@ -30,7 +30,7 @@ export default class StudentAgents extends React.Component {
                 <AgentDisplay
                   key={agent.name}
                   userId={agent.userId}
-                  statusTimer={agent.statusTimer}
+                  statusTimer={agent.statusChangeTime}
                   callsTaken={agent.callsTaken}
                 />
               ];
@@ -44,7 +44,7 @@ export default class StudentAgents extends React.Component {
                 <AgentDisplay
                   key={agent.name}
                   userId={agent.userId}
-                  statusTimer={agent.statusTimer}
+                  statusTimer={agent.statusChangeTime}
                   callsTaken={agent.callsTaken}
                 />
               ];

--- a/client/src/components/StudentPhones/StudentAgents/StudentAgents.js
+++ b/client/src/components/StudentPhones/StudentAgents/StudentAgents.js
@@ -6,10 +6,10 @@ export default class StudentAgents extends React.Component {
     let studentAvailable = [];
     let studentOnCall = [];
     this.props.studentQueue.forEach(agent => {
-      if (agent.status === "Available") {
+      if (agent.agentStatus === "Available") {
         studentAvailable.push(agent);
       }
-      if (agent.status === "On a Call") {
+      if (agent.agentStatus === "On a Call") {
         studentOnCall.push(agent);
       }
     });

--- a/client/src/components/StudentPhones/StudentPaused/StudentPaused.js
+++ b/client/src/components/StudentPhones/StudentPaused/StudentPaused.js
@@ -31,7 +31,7 @@ export default class StudentPaused extends React.Component {
                 <AgentDisplay
                   key={agent.name}
                   userId={agent.userId}
-                  statusTimer={agent.statusTimer}
+                  statusTimer={agent.statusChangeTime}
                   callsTaken={agent.callsTaken}
                 />
               ];
@@ -45,7 +45,7 @@ export default class StudentPaused extends React.Component {
                 <AgentDisplay
                   key={agent.name}
                   userId={agent.userId}
-                  statusTimer={agent.statusTimer}
+                  statusTimer={agent.statusChangeTime}
                   callsTaken={agent.callsTaken}
                 />
               ];

--- a/client/src/components/StudentPhones/StudentPaused/StudentPaused.js
+++ b/client/src/components/StudentPhones/StudentPaused/StudentPaused.js
@@ -6,10 +6,10 @@ export default class StudentPaused extends React.Component {
     let studentPaused = [];
     let studentUnavailable = [];
     this.props.studentQueue.forEach(agent => {
-      if (agent.status === "Paused") {
+      if (agent.agentStatus === "Paused") {
         studentPaused.push(agent);
       }
-      if (agent.status === "Unavailable") {
+      if (agent.agentStatus === "Unavailable") {
         studentUnavailable.push(agent);
       }
     });

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -11,7 +11,6 @@ class App extends Component {
   constructor() {
     super();
     this.state = {
-      agents: [],
       adminQueue: [],
       adminCallsWaiting: 0,
       adminWaitTime: 0,
@@ -30,11 +29,11 @@ class App extends Component {
   }
 
   // makes api calls to server, where data is stored
-  getAgents = async () => {
-    const res = await axios.get("/api/getAgents");
-    const response = res.data;
-    this.setState({ agents: response.agentEvents });
-  };
+  // getAgents = async () => {
+  //   const res = await axios.get("/api/getAgents");
+  //   const response = res.data;
+  //   this.setState({ agents: response.agentEvents });
+  // };
 
   getAdminQueue = async () => {
     const res = await axios.get("/api/adminQueue");
@@ -43,7 +42,7 @@ class App extends Component {
     let adminQueue = [...response.members];
 
     adminQueue.forEach(el => {
-      return (el.status = this.getStatus(el));
+      return (el.agentStatus = this.getStatus(el));
     });
 
     this.setState({
@@ -63,7 +62,7 @@ class App extends Component {
     let studentQueue = [...response.members];
 
     studentQueue.forEach(el => {
-      return (el.status = this.getStatus(el));
+      return (el.agentStatus = this.getStatus(el));
     });
 
     this.setState({
@@ -73,34 +72,6 @@ class App extends Component {
       studentCallsCompleted: response.numCompleted,
       studentCallsAbandoned: response.numAbandoned,
       studentSLA: response.serviceLevelPerf
-    });
-  };
-
-  replaceNames = () => {
-    // replaces names from admin/ student q with less crap ones
-    this.state.agents.forEach(agent => {
-      let peerName = agent.peerName;
-      let toChange = "";
-      if (agent.userId.includes(".instru")) {
-        toChange = agent.userId.replace(".instru", "");
-      } else if (agent.userId.includes("@instructure")) {
-        toChange = agent.userId.replace("@instructure.com", "");
-      } else {
-        toChange = agent.userId;
-      }
-
-      this.state.adminQueue.forEach(admin => {
-        let agentName = admin.name;
-        if (peerName === agentName) {
-          return (admin.userId = toChange);
-        }
-      });
-      this.state.studentQueue.forEach(student => {
-        let agentName = student.name;
-        if (peerName === agentName) {
-          return (student.userId = toChange);
-        }
-      });
     });
   };
 
@@ -135,16 +106,15 @@ class App extends Component {
 
   componentDidMount() {
     let getStats = () => {
-      this.getAgents();
+      //  this.getAgents();
       this.getAdminQueue();
       this.getStudentQueue();
     };
 
-    setInterval(() => getStats(), 5000);
+    setInterval(() => getStats(), 1000);
   }
 
   render() {
-    this.replaceNames();
     return (
       <div className="grid-container">
         <StudentPhones

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -40,40 +40,10 @@ class App extends Component {
     const res = await axios.get("/api/adminQueue");
     const response = res.data;
     let adminWaitTime = response.maxWaiting;
-    let temp = response.members;
+    let adminQueue = [...response.members];
 
-    let adminQueue = [...this.state.adminQueue];
-
-    temp.forEach(el => {
-      let name = el.name.substr(4);
-      el.name = name;
-      el.status = this.getStatus(el);
-    });
-
-    temp.forEach(agent => {
-      let admin = adminQueue.find(el => {
-        return el.name === agent.name;
-      });
-
-      if (!admin) {
-        let statusTime = Math.round(new Date().getTime() / 1000);
-        agent.statusChangeTime = statusTime;
-        if (agent.callsTaken === 0) {
-          agent.statusTimer = "—   ";
-        }
-        adminQueue.push(agent);
-      }
-
-      if (admin) {
-        if (admin.status !== agent.status) {
-          let statusTime = Math.round(new Date().getTime() / 1000);
-          admin.statusChangeTime = statusTime;
-          admin.status = agent.status;
-          if (admin.callsTaken === 0) {
-            admin.statusTimer = "—   ";
-          }
-        }
-      }
+    adminQueue.forEach(el => {
+      return (el.status = this.getStatus(el));
     });
 
     this.setState({
@@ -90,41 +60,12 @@ class App extends Component {
     const res = await axios.get("/api/studentQueue");
     const response = res.data;
     let studentWaitTime = response.maxWaiting;
-    let temp = response.members;
+    let studentQueue = [...response.members];
 
-    let studentQueue = [...this.state.studentQueue];
-
-    temp.forEach(el => {
-      let name = el.name.substr(4);
-      el.name = name;
-      el.status = this.getStatus(el);
+    studentQueue.forEach(el => {
+      return (el.status = this.getStatus(el));
     });
 
-    temp.forEach(agent => {
-      let student = studentQueue.find(el => {
-        return el.name === agent.name;
-      });
-
-      if (!student) {
-        let statusTime = Math.round(new Date().getTime() / 1000);
-        agent.statusChangeTime = statusTime;
-        if (agent.callsTaken === 0) {
-          agent.statusTimer = "—   ";
-        }
-        studentQueue.push(agent);
-      }
-
-      if (student) {
-        if (student.status !== agent.status) {
-          let statusTime = Math.round(new Date().getTime() / 1000);
-          student.statusChangeTime = statusTime;
-          student.status = agent.status;
-          if (student.callsTaken === 0) {
-            student.statusTimer = "—   ";
-          }
-        }
-      }
-    });
     this.setState({
       studentQueue: studentQueue,
       studentCallsWaiting: response.callsWaiting,
@@ -163,7 +104,7 @@ class App extends Component {
     });
   };
 
-  getStatus(agent) {
+  getStatus = agent => {
     // status codes
     // 1: "Available";
     // 2: "On a Call";
@@ -190,7 +131,7 @@ class App extends Component {
     if (agent.status === 5) {
       return (agent.status = "Unavailable");
     }
-  }
+  };
 
   componentDidMount() {
     let getStats = () => {

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -41,25 +41,43 @@ class App extends Component {
     const response = res.data;
     let adminWaitTime = response.maxWaiting;
     let temp = response.members;
-    for (let i = 0; i < temp.length; i++) {
-      // temp[i].agentName = this.replaceNames(temp[i]);
-      let name = temp[i].name.substring(4);
-      temp[i].name = name;
-      temp[i].status = this.getStatus(temp[i]);
-      // calucate agent's time in current state
-      let lastCall = temp[i].lastCall; // fuze API, lastCall returns a unix timestamp
-      let currentTime = Math.round(new Date().getTime() / 1000); // getTime() returns miliseconds, hence: `/ 1000`
-      let difference = currentTime - lastCall;
-      // error handling, lastCall doesn't return anything if the agent hasn't taken a call
-      if (temp[i].callsTaken === 0) {
-        temp[i].statusTimer = "—   ";
-      } else {
-        temp[i].statusTimer = this.ppSeconds(difference);
+
+    let adminQueue = [...this.state.adminQueue];
+
+    temp.forEach(el => {
+      let name = el.name.substr(4);
+      el.name = name;
+      el.status = this.getStatus(el);
+    });
+
+    temp.forEach(agent => {
+      let admin = adminQueue.find(el => {
+        return el.name === agent.name;
+      });
+
+      if (!admin) {
+        let statusTime = Math.round(new Date().getTime() / 1000);
+        agent.statusChangeTime = statusTime;
+        if (agent.callsTaken === 0) {
+          agent.statusTimer = "—   ";
+        }
+        adminQueue.push(agent);
       }
-    }
+
+      if (admin) {
+        if (admin.status !== agent.status) {
+          let statusTime = Math.round(new Date().getTime() / 1000);
+          admin.statusChangeTime = statusTime;
+          admin.status = agent.status;
+          if (admin.callsTaken === 0) {
+            admin.statusTimer = "—   ";
+          }
+        }
+      }
+    });
 
     this.setState({
-      adminQueue: temp,
+      adminQueue: adminQueue,
       adminCallsWaiting: response.callsWaiting,
       adminWaitTime: response.maxWaiting,
       adminCallsCompleted: response.numCompleted,
@@ -73,24 +91,42 @@ class App extends Component {
     const response = res.data;
     let studentWaitTime = response.maxWaiting;
     let temp = response.members;
-    for (let i = 0; i < temp.length; i++) {
-      // take respose and members array, and remove needless characters from name string
-      let name = temp[i].name.substring(4);
-      temp[i].name = name;
-      temp[i].status = this.getStatus(temp[i]);
-      // calucate agent's time in current state
-      let lastCall = temp[i].lastCall; // fuze API, lastCall returns a unix timestamp
-      let currentTime = Math.round(new Date().getTime() / 1000); // getTime() returns miliseconds, hence: `/ 1000`
-      let difference = currentTime - lastCall;
-      // error handling, lastCall doesn't return anything if the agent hasn't taken a call
-      if (temp[i].callsTaken === 0) {
-        temp[i].statusTimer = "—   ";
-      } else {
-        temp[i].statusTimer = this.ppSeconds(difference);
+
+    let studentQueue = [...this.state.studentQueue];
+
+    temp.forEach(el => {
+      let name = el.name.substr(4);
+      el.name = name;
+      el.status = this.getStatus(el);
+    });
+
+    temp.forEach(agent => {
+      let student = studentQueue.find(el => {
+        return el.name === agent.name;
+      });
+
+      if (!student) {
+        let statusTime = Math.round(new Date().getTime() / 1000);
+        agent.statusChangeTime = statusTime;
+        if (agent.callsTaken === 0) {
+          agent.statusTimer = "—   ";
+        }
+        studentQueue.push(agent);
       }
-    }
+
+      if (student) {
+        if (student.status !== agent.status) {
+          let statusTime = Math.round(new Date().getTime() / 1000);
+          student.statusChangeTime = statusTime;
+          student.status = agent.status;
+          if (student.callsTaken === 0) {
+            student.statusTimer = "—   ";
+          }
+        }
+      }
+    });
     this.setState({
-      studentQueue: temp,
+      studentQueue: studentQueue,
       studentCallsWaiting: response.callsWaiting,
       studentWaitTime: response.maxWaiting,
       studentCallsCompleted: response.numCompleted,
@@ -156,39 +192,6 @@ class App extends Component {
     }
   }
 
-  ppSeconds(time) {
-    let hours = Math.floor(time / 3600);
-    time %= 3600;
-    let minutes = Math.floor(time / 60);
-    let seconds = time % 60;
-    if (hours === 0 && minutes === 0 && seconds < 10) {
-      return "0:0" + seconds;
-    } else if (hours === 0 && minutes == 0) {
-      return "00:" + seconds;
-    } else if (hours === 0 && minutes < 10 && seconds < 10) {
-      return "0" + minutes + ":0" + seconds;
-    } else if (hours === 0 && minutes < 10) {
-      return "0" + minutes + ":" + seconds;
-    } else if (hours === 0 && seconds < 10) {
-      return minutes + ":0" + seconds;
-    } else if (hours === 0) {
-      return minutes + ":" + seconds;
-    } else if (hours > 1 && minutes === 0 && seconds < 10) {
-      return hours + ":00:0" + seconds;
-    } else if (hours > 1 && minutes == 0) {
-      return hours + ":00:" + seconds;
-    } else if (hours > 1 && minutes < 10 && seconds < 10) {
-      return hours + ":0" + minutes + ":0" + seconds;
-    } else if (hours > 1 && minutes < 10) {
-      return hours + ":0" + minutes + seconds;
-    } else if (hours > 1 && seconds < 10) {
-      return hours + ":" + minutes + ":0" + seconds;
-    } else if (hours > 1) {
-      return hours + ":" + minutes + ":" + seconds;
-    } else {
-      return "—   ";
-    }
-  }
   componentDidMount() {
     let getStats = () => {
       this.getAgents();

--- a/client/src/containers/Auth.js
+++ b/client/src/containers/Auth.js
@@ -10,9 +10,7 @@ export default class Auth {
   auth0 = new auth0.WebAuth({
     domain: DOMAIN,
     clientID: CLIENT_ID,
-    //redirectUri: "http://localhost:3000/callback",
     redirectUri: PROD_URL + "/callback",
-    //audience: "https://fuze-callboard.auth0.com/userinfo",
     responseType: "token id_token",
     scope: "openid"
   });

--- a/helpers/replaceNames.js
+++ b/helpers/replaceNames.js
@@ -1,0 +1,28 @@
+module.exports = replaceNames = (agentData, studentQueue, adminQueue) => {
+  // replaces names from admin/ student q with less crap ones
+  for (el in agentData) {
+    let peerName = agentData[el].peerName;
+    let toChange = "";
+    if (agentData[el].userId.includes(".instru")) {
+      toChange = agentData[el].userId.replace(".instru", "");
+    } else if (agentData[el].userId.includes("@instructure")) {
+      toChange = agentData[el].userId.replace("@instructure.com", "");
+    } else {
+      toChange = agentData[el].userId;
+    }
+
+    adminQueue.forEach(admin => {
+      let agentName = admin.name;
+      if (peerName === agentName) {
+        return (admin.userId = toChange);
+      }
+    });
+
+    studentQueue.forEach(student => {
+      let agentName = student.name;
+      if (peerName === agentName) {
+        return (student.userId = toChange);
+      }
+    });
+  }
+};

--- a/routes/fuzeRoutes.js
+++ b/routes/fuzeRoutes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 const keys = require("../config/keys");
+const replaceNames = require("../helpers/replaceNames");
 
 const API_TOKEN = keys.REACT_APP_API_TOKEN;
 const USERNAME = keys.REACT_APP_USERNAME;
@@ -31,7 +32,11 @@ module.exports = app => {
     temp.forEach(el => {
       let name = el.name.substr(4);
       el.name = name;
-      el.statusTime = Math.round(new Date().getTime() / 1000);
+      if (el.callsTaken === 0) {
+        el.statusChangeTime = "—   ";
+      } else {
+        el.statusChangeTime = el.lastCall;
+      }
     });
 
     if (!adminData.members) {
@@ -44,7 +49,7 @@ module.exports = app => {
       temp.forEach(agent => {
         let admin = agent;
 
-        adminQueue.forEach(el => {
+        let index = adminQueue.forEach(el => {
           if (el.name === agent.name) {
             admin = el;
           }
@@ -53,8 +58,11 @@ module.exports = app => {
         if (admin == agent) {
           let name = admin.name.substr(4);
           admin.name = name;
-          admin.statusTime = Math.round(new Date().getTime() / 1000);
-          adminQueue.push(admin);
+          if (admin.callsTaken === 0) {
+            admin.statusChangeTime = "—   ";
+          } else {
+            admin.statusChangeTime = admin.lastCall;
+          }
         }
 
         if (admin.status !== agent.status || admin.paused != agent.paused) {
@@ -81,7 +89,11 @@ module.exports = app => {
     temp.forEach(el => {
       let name = el.name.substr(4);
       el.name = name;
-      el.statusTime = Math.round(new Date().getTime() / 1000);
+      if (el.callsTaken === 0) {
+        el.statusChangeTime = "—   ";
+      } else {
+        el.statusChangeTime = el.lastCall;
+      }
     });
 
     if (!studentData.members) {
@@ -102,7 +114,11 @@ module.exports = app => {
         if (student == agent) {
           let name = student.name.substr(4);
           student.name = name;
-          student.statusTime = Math.round(new Date().getTime() / 1000);
+          if (student.callsTaken === 0) {
+            student.statusChangeTime = "—   ";
+          } else {
+            student.statusChangeTime = student.lastCall;
+          }
         }
 
         if (student.status !== agent.status || student.paused != agent.paused) {
@@ -133,9 +149,15 @@ module.exports = app => {
 
   // makes the above calls to fuze every 5 seconds. not browser based
   setInterval(() => {
-    getAdminData(), getStudentData(), getAgentData();
+    getAdminData(),
+      getStudentData(),
+      getAgentData(),
+      replaceNames(
+        agentData.agentEvents,
+        studentData.members,
+        adminData.members
+      );
   }, 5000);
-
   // these are the routes react reaches
   // they just return the data that is stored in the arrays
   // so it doesnt matter how many calls are made

--- a/routes/fuzeRoutes.js
+++ b/routes/fuzeRoutes.js
@@ -24,6 +24,49 @@ module.exports = app => {
     const response = await axios.get(url.replace("$QUEUE", ADMIN_QUEUE), {
       headers: { username: USERNAME, password: PASSWORD }
     });
+
+    let adminQueue = [];
+    let temp = response.data.members;
+
+    temp.forEach(el => {
+      let name = el.name.substr(4);
+      el.name = name;
+      el.statusTime = Math.round(new Date().getTime() / 1000);
+    });
+
+    if (!adminData.members) {
+      adminQueue = temp;
+    }
+
+    if (adminData.members) {
+      adminQueue = [...adminData.members];
+
+      temp.forEach(agent => {
+        let admin = agent;
+
+        adminQueue.forEach(el => {
+          if (el.name === agent.name) {
+            admin = el;
+          }
+        });
+
+        if (admin == agent) {
+          let name = admin.name.substr(4);
+          admin.name = name;
+          admin.statusTime = Math.round(new Date().getTime() / 1000);
+          adminQueue.push(admin);
+        }
+
+        if (admin.status !== agent.status || admin.paused != agent.paused) {
+          let statusTime = Math.round(new Date().getTime() / 1000);
+          admin.statusChangeTime = statusTime;
+          admin.callsTaken = agent.callsTaken;
+          admin.status = agent.status;
+          admin.paused = agent.paused;
+        }
+      });
+    }
+    response.data.members = adminQueue;
     return (adminData = response.data);
   };
 
@@ -31,6 +74,47 @@ module.exports = app => {
     const response = await axios.get(url.replace("$QUEUE", STUDENT_QUEUE), {
       headers: { username: USERNAME, password: PASSWORD }
     });
+
+    let studentQueue = [];
+    let temp = response.data.members;
+
+    temp.forEach(el => {
+      let name = el.name.substr(4);
+      el.name = name;
+      el.statusTime = Math.round(new Date().getTime() / 1000);
+    });
+
+    if (!studentData.members) {
+      studentQueue = temp;
+    }
+
+    if (studentData.members) {
+      studentQueue = [...studentData.members];
+
+      temp.forEach(agent => {
+        let student = agent;
+        studentQueue.forEach(async el => {
+          if (el.name === agent.name) {
+            student = el;
+          }
+        });
+
+        if (student == agent) {
+          let name = student.name.substr(4);
+          student.name = name;
+          student.statusTime = Math.round(new Date().getTime() / 1000);
+        }
+
+        if (student.status !== agent.status || student.paused != agent.paused) {
+          let statusTime = Math.round(new Date().getTime() / 1000);
+          student.statusChangeTime = statusTime;
+          student.callsTaken = agent.callsTaken;
+          student.status = agent.status;
+          student.paused = agent.paused;
+        }
+      });
+    }
+    response.data.members = studentQueue;
     return (studentData = response.data);
   };
 


### PR DESCRIPTION
should display the time an agent has been in a certain status, updates in 5 second increments  
truncate user names to 10 characters 

note for running local : atm the statusTimer is rendered locally. so each agents time will display as equal to the other until they begin to change status // we could change it to add the logic in the routes file, it would be a big refactor

closes #17 
closes #14 
closes #5 